### PR TITLE
Fix up tests for Clients, using mock.patch and monkeypatches insetad of mocker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 src/.pytest_cache/
-woqlClientP.sublime-project  
+woqlClientP.sublime-project
 woqlClientP.sublime-workspace
 
 src/tests/__pycache__/
@@ -32,3 +32,7 @@ venv/
 *.pyc
 *.swp
 *.egg
+
+#pytest
+
+.pytest_cache/

--- a/Pipfile
+++ b/Pipfile
@@ -4,15 +4,15 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-
-[packages]
 pytest = "*"
 pytest-mock = "*"
-requests = "*"
 autopep8 = "*"
 flake8 = "*"
 docutils-python3 = "*"
 pytest-cov = "*"
+
+[packages]
+requests = "*"
 
 [requires]
 python_version = "3.6"

--- a/src/tests/test_dispatchRequest.py
+++ b/src/tests/test_dispatchRequest.py
@@ -1,3 +1,4 @@
+import unittest.mock as mock
 from dispatchRequest import DispatchRequest
 import const
 import pytest
@@ -13,44 +14,39 @@ from pytest_mock import mocker
 def sendDispatchRequest(url,actionType,key,payload={}):
 	return DispatchRequest.sendRequestByAction(url, actionType,key, payload)
 
-@pytest.fixture()
-def test_connectCall(mocker):
+@mock.patch('requests.get')
+def test_connectCall(mocked_requests):
 	# Assert requests.get calls
 	#assert (1 == 2) == True
-	with mocker.patch('requests.get', side_effect=mockResponse.mocked_requests):
-		json_data=sendDispatchRequest('http://localhost:6363/', const.CONNECT, 'mykey')
+	json_data=sendDispatchRequest('http://localhost:6363/', const.CONNECT, 'mykey')
 
-		requests.get.assert_called_once_with('http://localhost:6363/', headers={'Authorization': 'Basic Om15a2V5'})
+	requests.get.assert_called_once_with('http://localhost:6363/', headers={'Authorization': 'Basic Om15a2V5'})
 
-@pytest.fixture()
-def test_createDataBase(mocker):
-	with mocker.patch('requests.post', side_effect=mockResponse.mocked_requests):
-		fullUrl="http://localhost:6363/myFirstTerminusDB"
+@mock.patch('requests.post')
+def test_createDataBase(mocked_requests):
+	fullUrl="http://localhost:6363/myFirstTerminusDB"
 
-		payload=DocumentTemplate.createDBTemplate("http://localhost:6363/","myFirstTerminusDB","my first terminusDB",comment="test terminusDB")
-		json_data = sendDispatchRequest(fullUrl, const.CREATE_DATABASE, "mykey" , payload)
-		#requests.post.assert_called_once_with('http://localhost:6363/myFirstTerminusDB', headers={'Authorization': 'Basic Om15a2V5', 'content-type': 'application/json'}, json={'@context': {'rdfs': 'http://www.w3.org/2000/01/rdf-schema#', 'terminus': 'http://terminusdb.com/schema/terminus#', '_': 'http://localhost:6363/myFirstTerminusDB/'}, 'terminus:document': {'@type': 'terminus:Database', 'rdfs:label': {'@language': 'en', '@value': 'my first terminusDB'}, 'rdfs:comment': {'@language': 'en', '@value': 'test terminusDB'}, 'terminus:allow_origin': {'@type': 'xsd:string', '@value': '*'}, '@id': 'http://localhost:6363/myFirstTerminusDB'}, '@type': 'terminus:APIUpdate'})
+	payload=DocumentTemplate.createDBTemplate("http://localhost:6363/","myFirstTerminusDB","my first terminusDB",comment="test terminusDB")
+	json_data = sendDispatchRequest(fullUrl, const.CREATE_DATABASE, "mykey" , payload)
+	#requests.post.assert_called_once_with('http://localhost:6363/myFirstTerminusDB', headers={'Authorization': 'Basic Om15a2V5', 'content-type': 'application/json'}, json={'@context': {'rdfs': 'http://www.w3.org/2000/01/rdf-schema#', 'terminus': 'http://terminusdb.com/schema/terminus#', '_': 'http://localhost:6363/myFirstTerminusDB/'}, 'terminus:document': {'@type': 'terminus:Database', 'rdfs:label': {'@language': 'en', '@value': 'my first terminusDB'}, 'rdfs:comment': {'@language': 'en', '@value': 'test terminusDB'}, 'terminus:allow_origin': {'@type': 'xsd:string', '@value': '*'}, '@id': 'http://localhost:6363/myFirstTerminusDB'}, '@type': 'terminus:APIUpdate'})
 
-@pytest.fixture()
-def test_getSchema(mocker):
-	with mocker.patch('requests.get', side_effect=mockResponse.mocked_requests):
-		payload = {"terminus:encoding":"terminus:turtle"}
-		string_data = sendDispatchRequest("http://localhost:6363/myFirstTerminusDB/schema", const.CONNECT, 'mykey', payload)
-		requests.get.assert_called_once_with('http://localhost:6363/myFirstTerminusDB/schema?terminus%3Aencoding=terminus%3Aturtle', headers={'Authorization': 'Basic Om15a2V5'})
+@mock.patch('requests.get')
+def test_getSchema(mocked_requests):
+	payload = {"terminus:encoding":"terminus:turtle"}
+	string_data = sendDispatchRequest("http://localhost:6363/myFirstTerminusDB/schema", const.CONNECT, 'mykey', payload)
+	requests.get.assert_called_once_with('http://localhost:6363/myFirstTerminusDB/schema?terminus%3Aencoding=terminus%3Aturtle', headers={'Authorization': 'Basic Om15a2V5'})
 
-@pytest.fixture()
-def test_woqlSelect(mocker):
-	with mocker.patch('requests.get', side_effect=mockResponse.mocked_requests):
-		payload = {'terminus:query':'{"@context":{"s":"http://localhost:6363/myFirstTerminusDB/schema#","dg":"http://localhost:6363/myFirstTerminusDB/schema","doc":"http://localhost:6363/myFirstTerminusDB/document/","db":"http://localhost:6363/myFirstTerminusDB/","g":"http://localhost:6363/","rdf":"http://www.w3.org/1999/02/22-rdf-syntax-ns#","rdfs":"http://www.w3.org/2000/01/rdf-schema#","xsd":"http://www.w3.org/2001/XMLSchema#","owl":"http://www.w3.org/2002/07/owl#","tcs":"http://terminusdb.com/schema/tcs#","tbs":"http://terminusdb.com/schema/tbs#","xdd":"http://terminusdb.com/schema/xdd#","terminus":"http://terminusdb.com/schema/terminus#","vio":"http://terminusdb.com/schema/vio#","docs":"http://terminusdb.com/schema/documentation#","scm":"http://localhost:6363/myFirstTerminusDB/schema#"},"from":["http://localhost:6363/myFirstTerminusDB",{"limit":[20,{"start":[0,{"and":[{"quad":["v:Element","rdf:type","owl:Class","db:schema"]},{"opt":[{"quad":["v:Element","rdfs:label","v:Label","db:schema"]}]},{"opt":[{"quad":["v:Element","rdfs:comment","v:Comment","db:schema"]}]},{"opt":[{"quad":["v:Element","tcs:tag","v:Abstract","db:schema"]}]}]}]}]}]}'}
-		fullUrl="http://localhost:6363/myFirstTerminusDB/woql"
-		json_data = sendDispatchRequest(fullUrl, const.WOQL_SELECT, 'mykey',  payload)
-		requests.get.assert_called_once_with("http://localhost:6363/myFirstTerminusDB/woql?terminus%3Aquery=%7B%22%40context%22%3A%7B%22s%22%3A%22http%3A%2F%2Flocalhost%3A6363%2FmyFirstTerminusDB%2Fschema%23%22%2C%22dg%22%3A%22http%3A%2F%2Flocalhost%3A6363%2FmyFirstTerminusDB%2Fschema%22%2C%22doc%22%3A%22http%3A%2F%2Flocalhost%3A6363%2FmyFirstTerminusDB%2Fdocument%2F%22%2C%22db%22%3A%22http%3A%2F%2Flocalhost%3A6363%2FmyFirstTerminusDB%2F%22%2C%22g%22%3A%22http%3A%2F%2Flocalhost%3A6363%2F%22%2C%22rdf%22%3A%22http%3A%2F%2Fwww.w3.org%2F1999%2F02%2F22-rdf-syntax-ns%23%22%2C%22rdfs%22%3A%22http%3A%2F%2Fwww.w3.org%2F2000%2F01%2Frdf-schema%23%22%2C%22xsd%22%3A%22http%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%22%2C%22owl%22%3A%22http%3A%2F%2Fwww.w3.org%2F2002%2F07%2Fowl%23%22%2C%22tcs%22%3A%22http%3A%2F%2Fterminusdb.com%2Fschema%2Ftcs%23%22%2C%22tbs%22%3A%22http%3A%2F%2Fterminusdb.com%2Fschema%2Ftbs%23%22%2C%22xdd%22%3A%22http%3A%2F%2Fterminusdb.com%2Fschema%2Fxdd%23%22%2C%22terminus%22%3A%22http%3A%2F%2Fterminusdb.com%2Fschema%2Fterminus%23%22%2C%22vio%22%3A%22http%3A%2F%2Fterminusdb.com%2Fschema%2Fvio%23%22%2C%22docs%22%3A%22http%3A%2F%2Fterminusdb.com%2Fschema%2Fdocumentation%23%22%2C%22scm%22%3A%22http%3A%2F%2Flocalhost%3A6363%2FmyFirstTerminusDB%2Fschema%23%22%7D%2C%22from%22%3A%5B%22http%3A%2F%2Flocalhost%3A6363%2FmyFirstTerminusDB%22%2C%7B%22limit%22%3A%5B20%2C%7B%22start%22%3A%5B0%2C%7B%22and%22%3A%5B%7B%22quad%22%3A%5B%22v%3AElement%22%2C%22rdf%3Atype%22%2C%22owl%3AClass%22%2C%22db%3Aschema%22%5D%7D%2C%7B%22opt%22%3A%5B%7B%22quad%22%3A%5B%22v%3AElement%22%2C%22rdfs%3Alabel%22%2C%22v%3ALabel%22%2C%22db%3Aschema%22%5D%7D%5D%7D%2C%7B%22opt%22%3A%5B%7B%22quad%22%3A%5B%22v%3AElement%22%2C%22rdfs%3Acomment%22%2C%22v%3AComment%22%2C%22db%3Aschema%22%5D%7D%5D%7D%2C%7B%22opt%22%3A%5B%7B%22quad%22%3A%5B%22v%3AElement%22%2C%22tcs%3Atag%22%2C%22v%3AAbstract%22%2C%22db%3Aschema%22%5D%7D%5D%7D%5D%7D%5D%7D%5D%7D%5D%7D"
-											, headers={'Authorization': 'Basic Om15a2V5'})
+@mock.patch('requests.get')
+def test_woqlSelect(mocked_requests):
+	payload = {'terminus:query':'{"@context":{"s":"http://localhost:6363/myFirstTerminusDB/schema#","dg":"http://localhost:6363/myFirstTerminusDB/schema","doc":"http://localhost:6363/myFirstTerminusDB/document/","db":"http://localhost:6363/myFirstTerminusDB/","g":"http://localhost:6363/","rdf":"http://www.w3.org/1999/02/22-rdf-syntax-ns#","rdfs":"http://www.w3.org/2000/01/rdf-schema#","xsd":"http://www.w3.org/2001/XMLSchema#","owl":"http://www.w3.org/2002/07/owl#","tcs":"http://terminusdb.com/schema/tcs#","tbs":"http://terminusdb.com/schema/tbs#","xdd":"http://terminusdb.com/schema/xdd#","terminus":"http://terminusdb.com/schema/terminus#","vio":"http://terminusdb.com/schema/vio#","docs":"http://terminusdb.com/schema/documentation#","scm":"http://localhost:6363/myFirstTerminusDB/schema#"},"from":["http://localhost:6363/myFirstTerminusDB",{"limit":[20,{"start":[0,{"and":[{"quad":["v:Element","rdf:type","owl:Class","db:schema"]},{"opt":[{"quad":["v:Element","rdfs:label","v:Label","db:schema"]}]},{"opt":[{"quad":["v:Element","rdfs:comment","v:Comment","db:schema"]}]},{"opt":[{"quad":["v:Element","tcs:tag","v:Abstract","db:schema"]}]}]}]}]}]}'}
+	fullUrl="http://localhost:6363/myFirstTerminusDB/woql"
+	json_data = sendDispatchRequest(fullUrl, const.WOQL_SELECT, 'mykey',  payload)
+	requests.get.assert_called_once_with("http://localhost:6363/myFirstTerminusDB/woql?terminus%3Aquery=%7B%22%40context%22%3A%7B%22s%22%3A%22http%3A%2F%2Flocalhost%3A6363%2FmyFirstTerminusDB%2Fschema%23%22%2C%22dg%22%3A%22http%3A%2F%2Flocalhost%3A6363%2FmyFirstTerminusDB%2Fschema%22%2C%22doc%22%3A%22http%3A%2F%2Flocalhost%3A6363%2FmyFirstTerminusDB%2Fdocument%2F%22%2C%22db%22%3A%22http%3A%2F%2Flocalhost%3A6363%2FmyFirstTerminusDB%2F%22%2C%22g%22%3A%22http%3A%2F%2Flocalhost%3A6363%2F%22%2C%22rdf%22%3A%22http%3A%2F%2Fwww.w3.org%2F1999%2F02%2F22-rdf-syntax-ns%23%22%2C%22rdfs%22%3A%22http%3A%2F%2Fwww.w3.org%2F2000%2F01%2Frdf-schema%23%22%2C%22xsd%22%3A%22http%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%22%2C%22owl%22%3A%22http%3A%2F%2Fwww.w3.org%2F2002%2F07%2Fowl%23%22%2C%22tcs%22%3A%22http%3A%2F%2Fterminusdb.com%2Fschema%2Ftcs%23%22%2C%22tbs%22%3A%22http%3A%2F%2Fterminusdb.com%2Fschema%2Ftbs%23%22%2C%22xdd%22%3A%22http%3A%2F%2Fterminusdb.com%2Fschema%2Fxdd%23%22%2C%22terminus%22%3A%22http%3A%2F%2Fterminusdb.com%2Fschema%2Fterminus%23%22%2C%22vio%22%3A%22http%3A%2F%2Fterminusdb.com%2Fschema%2Fvio%23%22%2C%22docs%22%3A%22http%3A%2F%2Fterminusdb.com%2Fschema%2Fdocumentation%23%22%2C%22scm%22%3A%22http%3A%2F%2Flocalhost%3A6363%2FmyFirstTerminusDB%2Fschema%23%22%7D%2C%22from%22%3A%5B%22http%3A%2F%2Flocalhost%3A6363%2FmyFirstTerminusDB%22%2C%7B%22limit%22%3A%5B20%2C%7B%22start%22%3A%5B0%2C%7B%22and%22%3A%5B%7B%22quad%22%3A%5B%22v%3AElement%22%2C%22rdf%3Atype%22%2C%22owl%3AClass%22%2C%22db%3Aschema%22%5D%7D%2C%7B%22opt%22%3A%5B%7B%22quad%22%3A%5B%22v%3AElement%22%2C%22rdfs%3Alabel%22%2C%22v%3ALabel%22%2C%22db%3Aschema%22%5D%7D%5D%7D%2C%7B%22opt%22%3A%5B%7B%22quad%22%3A%5B%22v%3AElement%22%2C%22rdfs%3Acomment%22%2C%22v%3AComment%22%2C%22db%3Aschema%22%5D%7D%5D%7D%2C%7B%22opt%22%3A%5B%7B%22quad%22%3A%5B%22v%3AElement%22%2C%22tcs%3Atag%22%2C%22v%3AAbstract%22%2C%22db%3Aschema%22%5D%7D%5D%7D%5D%7D%5D%7D%5D%7D%5D%7D"
+										, headers={'Authorization': 'Basic Om15a2V5'})
 
-@pytest.fixture()
-def test_deleteDatabase(mocker):
-	with mocker.patch('requests.delete', side_effect=mockResponse.mocked_requests):
-		fullUrl="http://localhost:6363/myFirstTerminusDB"
-		json_data = sendDispatchRequest(fullUrl, const.DELETE_DATABASE, 'mykey')
-		requests.delete.assert_called_once_with('http://localhost:6363/myFirstTerminusDB', headers={'Authorization': 'Basic Om15a2V5'})
-		#print("call_args_list", requests.delete.call_args_list)
+@mock.patch('requests.delete')
+def test_deleteDatabase(mocked_requests):
+	fullUrl="http://localhost:6363/myFirstTerminusDB"
+	json_data = sendDispatchRequest(fullUrl, const.DELETE_DATABASE, 'mykey')
+	requests.delete.assert_called_once_with('http://localhost:6363/myFirstTerminusDB', headers={'Authorization': 'Basic Om15a2V5'})
+	#print("call_args_list", requests.delete.call_args_list)

--- a/src/tests/test_dispatchRequest.py
+++ b/src/tests/test_dispatchRequest.py
@@ -10,9 +10,10 @@ from documentTemplate import DocumentTemplate
 
 from pytest_mock import mocker
 
-def sendDispatchRequest(url,actionType,key,payload={}): 
+def sendDispatchRequest(url,actionType,key,payload={}):
 	return DispatchRequest.sendRequestByAction(url, actionType,key, payload)
 
+@pytest.fixture()
 def test_connectCall(mocker):
 	# Assert requests.get calls
 	#assert (1 == 2) == True
@@ -21,6 +22,7 @@ def test_connectCall(mocker):
 
 		requests.get.assert_called_once_with('http://localhost:6363/', headers={'Authorization': 'Basic Om15a2V5'})
 
+@pytest.fixture()
 def test_createDataBase(mocker):
 	with mocker.patch('requests.post', side_effect=mockResponse.mocked_requests):
 		fullUrl="http://localhost:6363/myFirstTerminusDB"
@@ -29,13 +31,14 @@ def test_createDataBase(mocker):
 		json_data = sendDispatchRequest(fullUrl, const.CREATE_DATABASE, "mykey" , payload)
 		#requests.post.assert_called_once_with('http://localhost:6363/myFirstTerminusDB', headers={'Authorization': 'Basic Om15a2V5', 'content-type': 'application/json'}, json={'@context': {'rdfs': 'http://www.w3.org/2000/01/rdf-schema#', 'terminus': 'http://terminusdb.com/schema/terminus#', '_': 'http://localhost:6363/myFirstTerminusDB/'}, 'terminus:document': {'@type': 'terminus:Database', 'rdfs:label': {'@language': 'en', '@value': 'my first terminusDB'}, 'rdfs:comment': {'@language': 'en', '@value': 'test terminusDB'}, 'terminus:allow_origin': {'@type': 'xsd:string', '@value': '*'}, '@id': 'http://localhost:6363/myFirstTerminusDB'}, '@type': 'terminus:APIUpdate'})
 
+@pytest.fixture()
 def test_getSchema(mocker):
 	with mocker.patch('requests.get', side_effect=mockResponse.mocked_requests):
 		payload = {"terminus:encoding":"terminus:turtle"}
 		string_data = sendDispatchRequest("http://localhost:6363/myFirstTerminusDB/schema", const.CONNECT, 'mykey', payload)
 		requests.get.assert_called_once_with('http://localhost:6363/myFirstTerminusDB/schema?terminus%3Aencoding=terminus%3Aturtle', headers={'Authorization': 'Basic Om15a2V5'})
 
-
+@pytest.fixture()
 def test_woqlSelect(mocker):
 	with mocker.patch('requests.get', side_effect=mockResponse.mocked_requests):
 		payload = {'terminus:query':'{"@context":{"s":"http://localhost:6363/myFirstTerminusDB/schema#","dg":"http://localhost:6363/myFirstTerminusDB/schema","doc":"http://localhost:6363/myFirstTerminusDB/document/","db":"http://localhost:6363/myFirstTerminusDB/","g":"http://localhost:6363/","rdf":"http://www.w3.org/1999/02/22-rdf-syntax-ns#","rdfs":"http://www.w3.org/2000/01/rdf-schema#","xsd":"http://www.w3.org/2001/XMLSchema#","owl":"http://www.w3.org/2002/07/owl#","tcs":"http://terminusdb.com/schema/tcs#","tbs":"http://terminusdb.com/schema/tbs#","xdd":"http://terminusdb.com/schema/xdd#","terminus":"http://terminusdb.com/schema/terminus#","vio":"http://terminusdb.com/schema/vio#","docs":"http://terminusdb.com/schema/documentation#","scm":"http://localhost:6363/myFirstTerminusDB/schema#"},"from":["http://localhost:6363/myFirstTerminusDB",{"limit":[20,{"start":[0,{"and":[{"quad":["v:Element","rdf:type","owl:Class","db:schema"]},{"opt":[{"quad":["v:Element","rdfs:label","v:Label","db:schema"]}]},{"opt":[{"quad":["v:Element","rdfs:comment","v:Comment","db:schema"]}]},{"opt":[{"quad":["v:Element","tcs:tag","v:Abstract","db:schema"]}]}]}]}]}]}'}
@@ -44,10 +47,10 @@ def test_woqlSelect(mocker):
 		requests.get.assert_called_once_with("http://localhost:6363/myFirstTerminusDB/woql?terminus%3Aquery=%7B%22%40context%22%3A%7B%22s%22%3A%22http%3A%2F%2Flocalhost%3A6363%2FmyFirstTerminusDB%2Fschema%23%22%2C%22dg%22%3A%22http%3A%2F%2Flocalhost%3A6363%2FmyFirstTerminusDB%2Fschema%22%2C%22doc%22%3A%22http%3A%2F%2Flocalhost%3A6363%2FmyFirstTerminusDB%2Fdocument%2F%22%2C%22db%22%3A%22http%3A%2F%2Flocalhost%3A6363%2FmyFirstTerminusDB%2F%22%2C%22g%22%3A%22http%3A%2F%2Flocalhost%3A6363%2F%22%2C%22rdf%22%3A%22http%3A%2F%2Fwww.w3.org%2F1999%2F02%2F22-rdf-syntax-ns%23%22%2C%22rdfs%22%3A%22http%3A%2F%2Fwww.w3.org%2F2000%2F01%2Frdf-schema%23%22%2C%22xsd%22%3A%22http%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%22%2C%22owl%22%3A%22http%3A%2F%2Fwww.w3.org%2F2002%2F07%2Fowl%23%22%2C%22tcs%22%3A%22http%3A%2F%2Fterminusdb.com%2Fschema%2Ftcs%23%22%2C%22tbs%22%3A%22http%3A%2F%2Fterminusdb.com%2Fschema%2Ftbs%23%22%2C%22xdd%22%3A%22http%3A%2F%2Fterminusdb.com%2Fschema%2Fxdd%23%22%2C%22terminus%22%3A%22http%3A%2F%2Fterminusdb.com%2Fschema%2Fterminus%23%22%2C%22vio%22%3A%22http%3A%2F%2Fterminusdb.com%2Fschema%2Fvio%23%22%2C%22docs%22%3A%22http%3A%2F%2Fterminusdb.com%2Fschema%2Fdocumentation%23%22%2C%22scm%22%3A%22http%3A%2F%2Flocalhost%3A6363%2FmyFirstTerminusDB%2Fschema%23%22%7D%2C%22from%22%3A%5B%22http%3A%2F%2Flocalhost%3A6363%2FmyFirstTerminusDB%22%2C%7B%22limit%22%3A%5B20%2C%7B%22start%22%3A%5B0%2C%7B%22and%22%3A%5B%7B%22quad%22%3A%5B%22v%3AElement%22%2C%22rdf%3Atype%22%2C%22owl%3AClass%22%2C%22db%3Aschema%22%5D%7D%2C%7B%22opt%22%3A%5B%7B%22quad%22%3A%5B%22v%3AElement%22%2C%22rdfs%3Alabel%22%2C%22v%3ALabel%22%2C%22db%3Aschema%22%5D%7D%5D%7D%2C%7B%22opt%22%3A%5B%7B%22quad%22%3A%5B%22v%3AElement%22%2C%22rdfs%3Acomment%22%2C%22v%3AComment%22%2C%22db%3Aschema%22%5D%7D%5D%7D%2C%7B%22opt%22%3A%5B%7B%22quad%22%3A%5B%22v%3AElement%22%2C%22tcs%3Atag%22%2C%22v%3AAbstract%22%2C%22db%3Aschema%22%5D%7D%5D%7D%5D%7D%5D%7D%5D%7D%5D%7D"
 											, headers={'Authorization': 'Basic Om15a2V5'})
 
+@pytest.fixture()
 def test_deleteDatabase(mocker):
 	with mocker.patch('requests.delete', side_effect=mockResponse.mocked_requests):
 		fullUrl="http://localhost:6363/myFirstTerminusDB"
 		json_data = sendDispatchRequest(fullUrl, const.DELETE_DATABASE, 'mykey')
 		requests.delete.assert_called_once_with('http://localhost:6363/myFirstTerminusDB', headers={'Authorization': 'Basic Om15a2V5'})
 		#print("call_args_list", requests.delete.call_args_list)
-


### PR DESCRIPTION
As mocker does not support using within a `with` context, we have to switch to unitestmock.patch and monkeypatches for some tests. It passes the travis so far.