### PR TITLE
Change the query internally when using property method

### DIFF
--- a/tests/test_woql.py
+++ b/tests/test_woql.py
@@ -500,3 +500,14 @@ class TestTripleBuilderChainer:
         { "add_quad": ["scm:prop2", "rdfs:label", {"@value": "abe", "@language": "en"}, "db:schema"] }
         ]}
         assert woqlObject.json() == jsonObj
+
+    def test_chained_property_method(self):
+        woqlObject = WOQLQuery().doctype("Journey")
+        woqlObject = woqlObject.property(
+        "start_station", "Station").label("Start Station")
+
+        woqlObject2 = WOQLQuery().doctype("Journey")
+        woqlObject2.property(
+        "start_station", "Station").label("Start Station")
+
+        assert woqlObject.json() == woqlObject2.json()

--- a/woqlclient/woql.py
+++ b/woqlclient/woql.py
@@ -1586,7 +1586,10 @@ class WOQLQuery:
                 domain(self.adding_class)
                 nwoql.query["and"].append(self.json())
                 nwoql.adding_class = self.adding_class
-                return nwoql
+                self.query = nwoql.query
+                self.cursor = nwoql.cursor
+                self.tripleBuilder = nwoql.tripleBuilder
+                return self
             p = self._clean_predicate(p)
             self.tripleBuilder.addPO(p, val)
         return self


### PR DESCRIPTION
Now instead of doing:
journey = WOQLQuery().doctype("Journey")
journey = journey.property(
        "start_station", "Station").label("Start Station")

You can just do:
journey = WOQLQuery().doctype("Journey")
journey.property(
        "start_station", "Station").label("Start Station")