### PR TITLE
woql.py: fix concat function

### DIFF
--- a/woqlclient/woql.py
+++ b/woqlclient/woql.py
@@ -495,10 +495,10 @@ class WOQLQuery:
                    (nlist[i][:1] == ":"):
                    nlist[i-1] = nlist[i-1][:len(nlist[i-1])-1]
                    nlist[i] = nlist[i][1:]
-        elif 'list' in list:
-            nlist = list['list']
-        elif isinstance(list, (list, dict, WOQLQuery)):
-            nlist = list
+        elif 'list' in lst:
+            nlist = lst['list']
+        elif isinstance(lst, (list, dict, WOQLQuery)):
+            nlist = lst
         args = self._pack_strings(nlist)
         if v.find(":") == -1:
             v = "v:" + v


### PR DESCRIPTION
The concat function probably had a typo, since it was checking
if "list" was a dict key in the type list itself, but not in the
variable.